### PR TITLE
Add trend icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ key | type | description
 **purchase_price (Optional)**              | number        | Price paid when stock was purchased (per share). Redundant if stock is defined as a list.
 **conversion_currency (Optional)**         | number        | Index id used for currency conversion, see [here](#finding-stock-or-conversion-currency).
 **monitored_conditions (Optional)**        | list          | Attributes to monitor, see [here](#monitored-conditions).
+**show_trending_icon (Optional)**          | boolean       | Show trending icons (up/down/neutral) instead of cash icon, default false.
 **invert_conversion_currency (Optional)** | boolean       | Wether or not to invert the conversion currency, default false.
 **currency (Optional)**                    | string        | Overwrite currency given by the api.
 
@@ -136,6 +137,18 @@ sensor:
         currency: SEK
 ```
 
+**Configuration with trending icons:**
+
+```yaml
+sensor:
+  - platform: avanza_stock
+    stock: 5361
+    show_trending_icon: true
+    monitored_conditions:
+      - change
+      - changePercent
+```
+
 ## Usage
 
 **Automation to send summary at 18:00 using telegram:**
@@ -162,6 +175,7 @@ sensor:
 
 ## Changelog
 
+- 1.5.4  - Add trend icons
 - 1.5.3  - Less aggressive rounding
 - 1.5.2  - Add minimum home-assistant version
 - 1.5.1  - Bump pyavanza (becuase of aiohttp)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If no `monitored_conditions` is defined, change, changePercent and name will be 
 
 ### Finding stock or conversion currency
 
-Got to [Avanza](https://www.avanza.se) and search for the stock you want to track. In the resulting url there is a number, this is the stock id needed for the configuration. Even though it is a Swedish bank it is possible to find stocks from the following countries: Sweden, USA, Denmark, Norway, Finland, Canada, Belgium, France, Italy, Netherlands, Portugal and Germany. To find conversion currencies search for example "USD/SEK" and look for the id in the resulting url. If you can not find your conversion try and search the reverse (NOK/SEK instead of SEK/NOK) and use the `invert_conversion_currency` to get your preffered currency.
+Go to [Avanza](https://www.avanza.se) and search for the stock you want to track. In the resulting url there is a number, this is the stock id needed for the configuration. Even though it is a Swedish bank it is possible to find stocks from the following countries: Sweden, USA, Denmark, Norway, Finland, Canada, Belgium, France, Italy, Netherlands, Portugal and Germany. To find conversion currencies search for example "USD/SEK" and look for the id in the resulting url. If you can not find your conversion try and search the reverse (NOK/SEK instead of SEK/NOK) and use the `invert_conversion_currency` to get your preffered currency.
 
 ## Example
 

--- a/custom_components/avanza_stock/const.py
+++ b/custom_components/avanza_stock/const.py
@@ -9,6 +9,13 @@ CONF_PURCHASE_DATE = "purchase_date"
 CONF_PURCHASE_PRICE = "purchase_price"
 CONF_CONVERSION_CURRENCY = "conversion_currency"
 CONF_INVERT_CONVERSION_CURRENCY = "invert_conversion_currency"
+CONF_SHOW_TRENDING_ICON = "show_trending_icon"
+
+# Attribute keys for extra state attributes
+ATTR_TRENDING = "trending"
+
+# Default configuration values
+DEFAULT_SHOW_TRENDING_ICON = False
 
 MONITORED_CONDITIONS = [
     "country",

--- a/custom_components/avanza_stock/const.py
+++ b/custom_components/avanza_stock/const.py
@@ -1,5 +1,5 @@
 """Constants for avanza_stock."""
-__version__ = "1.5.3"
+__version__ = "1.5.4"
 
 DEFAULT_NAME = "Avanza Stock"
 

--- a/custom_components/avanza_stock/manifest.json
+++ b/custom_components/avanza_stock/manifest.json
@@ -11,5 +11,5 @@
   "requirements": [
     "pyavanza==0.7.1"
   ],
-  "version": "1.5.3"
+  "version": "1.5.4"
 }

--- a/custom_components/avanza_stock/sensor.py
+++ b/custom_components/avanza_stock/sensor.py
@@ -79,7 +79,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_CONVERSION_CURRENCY): cv.positive_int,
         vol.Optional(CONF_INVERT_CONVERSION_CURRENCY, default=False): cv.boolean,
         vol.Optional(CONF_CURRENCY): cv.string,
-        vol.Optional(CONF_SHOW_TRENDING_ICON, default=DEFAULT_SHOW_TRENDING_ICON): cv.boolean,
+        vol.Optional(
+            CONF_SHOW_TRENDING_ICON, default=DEFAULT_SHOW_TRENDING_ICON
+        ): cv.boolean,
         vol.Optional(
             CONF_MONITORED_CONDITIONS, default=MONITORED_CONDITIONS_DEFAULT
         ): vol.All(cv.ensure_list, [vol.In(MONITORED_CONDITIONS)]),
@@ -268,11 +270,17 @@ class AvanzaStockSensor(SensorEntity):
             # Store previous close price for trending calculation
             if "quote" in data and "last" in data["quote"] and self._stock != 0:
                 # Try to get previous close from historical data or use the change to calculate it
-                if "historicalClosingPrices" in data and data["historicalClosingPrices"]:
+                if (
+                    "historicalClosingPrices" in data
+                    and data["historicalClosingPrices"]
+                ):
                     # Use any available historical closing price as reference
                     historical_prices = data["historicalClosingPrices"]
                     for period in ["oneWeek", "oneMonth", "threeMonths", "startOfYear"]:
-                        if period in historical_prices and historical_prices[period] is not None:
+                        if (
+                            period in historical_prices
+                            and historical_prices[period] is not None
+                        ):
                             # For trending, we'll use current price vs previous close logic
                             # Avanza API provides 'change' which is current - previous close
                             change = data["quote"].get("change", 0)
@@ -458,7 +466,7 @@ class AvanzaStockSensor(SensorEntity):
     def _update_trending_and_icon(self, data):
         """Update the trending state and icon based on price movement."""
         trending_state = self._calc_trending_state()
-        
+
         # Set trending attribute if we have a valid state
         if trending_state is not None:
             self._state_attributes[ATTR_TRENDING] = trending_state


### PR DESCRIPTION
Inspired by functionality from [YahooFinance](https://github.com/iprak/yahoofinance/tree/master/custom_components/yahoofinance) that shows trending icons mdi:up|down|neutral based on changes (rather than mdi:cash) which is used as default/fallback.

![avanza_trend_icon](https://github.com/user-attachments/assets/52d9ce96-ab7d-4b8b-926e-c151db01f8ab)


> [!NOTE]
> As I ruined the initial pull request by polluting a local branch I wanted to develop further, here is a second attempt while I get more comfortable working with git. Sorry for the inconvenience, and hope that the added flair to your already excellent plugin makes up for some of this.